### PR TITLE
Add .gitignore to ignore system and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE/editor folders
+.vscode/
+.idea/
+
+# Environment/config files
+.env
+*.env
+
+# Logs (in case someone adds them)
+*.log
+
+# Node (for future usage)
+node_modules/
+
+# Optional: system crash reports
+*.pid
+
+# Optional: Mac system files
+.AppleDouble
+.LSOverride
+Icon?
+
+# Optional: Windows system files
+Desktop.ini
+
+# Backup files
+*~
+*.bak
+*.swp
+*.tmp


### PR DESCRIPTION
## 📌 Description

Added a `.gitignore` file to exclude unnecessary files and folders (e.g., `node_modules`, `.env`, OS-specific files) from being tracked in version control.

This helps keep the repo clean and avoids committing sensitive or bulky files.

## 🔍 Additional Notes

Let me know if you'd like any specific patterns added or removed from the `.gitignore`.
