### PR TITLE
Add .gitignore file to improve project hygiene and prepare for future backend integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# macOS system files
+.DS_Store
+
+# Logs
+*.log
+
+# Dependency directories (if used in future)
+node_modules/
+bower_components/
+
+# Build outputs (if added later)
+dist/
+build/
+
+# Environment files (for backend projects)
+.env
+
+# OS generated files
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# IDE/Editor settings
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+# Backup files
+*.bak
+*.tmp
+*.swp
+
+# Git directory backup
+*.orig


### PR DESCRIPTION
This pull request introduces a .gitignore file to the repository to help maintain a clean and secure development environment.

Although this project currently focuses on the frontend and does not contain backend-related files like node_modules/ or .env, adding a .gitignore file now ensures the repository is well-prepared for future expansion.

If backend features or build tools are integrated later (e.g., Node.js, Express, React, or a deployment setup), this .gitignore will already handle commonly ignored files and folders such as:

macOS system files (.DS_Store)

Dependency folders (node_modules/)

IDE/editor config folders (.vscode/, .idea/)

Log files, build outputs, and environment files (*.log, .env, dist/)

This proactive update improves security, performance, and collaboration by preventing sensitive or unnecessary files from being committed to the repository.

