### PR TITLE
Fixed: "Back to Top" Link in README (Issue #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a id="top"></a>
 # 🚀 JOBSYNC – AI-Powered Job Opportunity Finder
 
 ### 🏆 Built at a Hackathon | **Top 5 out of 30+ Teams!**
@@ -375,7 +376,7 @@ This project is licensed under the **MIT License** - see the [LICENSE](./LICENSE
 
 **Made with ❤️ for the open source community**
 
-[⬆ Back to Top](#jobsync--ai-powered-job-opportunity-finder)
+[⬆ Back to Top](#top)
 
 </div>
 ```


### PR DESCRIPTION
The original "⬆ Back to Top" link in the README.md was pointing to a long, unreliable anchor based on the heading text. This caused it to fail in some cases.

Changes Made:
Added a custom anchor: <a id="top"></a> at the top of the README
Updated the link at the bottom to [⬆ Back to Top](#top)

UX Improvement: Improves the user experience by ensuring that the "Back to Top" link reliably navigates to the top of the README on GitHub.

Tested on GitHub markdown preview – verified that the link now scrolls to the top correctly.