### PR TITLE
Enhance: Close menu on outside click

### DIFF
--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -74,4 +74,14 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   menuToggleBtn.addEventListener("click", toggleMenu);
+
+  // Close when clicking outside the menu
+  document.addEventListener("click", function (event) {
+    const isClickOnToggle = menuToggleBtn.contains(event.target);
+    const isClickInsideMenu = event.target.closest(".menu-items");
+
+    if (!isClickInsideMenu && !isClickOnToggle && isMenuOpen) {
+      toggleMenu();
+    }
+  });
 });


### PR DESCRIPTION
### Description
This PR fixes the issue where the dropdown menu remained open after clicking outside of it.

### Changes Made
- Added a global click listener on `document`
- Detects when a click is outside both the `.menu-items` and the `.menu-icon`
- Calls `toggleMenu()` to close the menu gracefully
- Tested on desktop (mouse, touchpad) and responsive mobile view

### Affected Files
- `public/js/menu.js`
