### PR TITLE
Fix: Re-implement menu close on outside click using latest repo state

### DIFF
--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -74,4 +74,15 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   menuToggleBtn.addEventListener("click", toggleMenu);
+
+  // Close when clicking outside the menu
+  document.addEventListener("click", function (event) {
+    const isClickOnToggle = menuToggleBtn.contains(event.target);
+    const isClickInsideMenu = event.target.closest(".menu-items");
+
+    if (!isClickInsideMenu && !isClickOnToggle && isMenuOpen) {
+      toggleMenu();
+    }
+  });
+
 });


### PR DESCRIPTION
### 🔧 Description

This PR reintroduces the **"menu close on outside click"** functionality, which was previously implemented but appears to have been removed in recent changes to the codebase.

The fix ensures that:
- When the menu is open, clicking anywhere outside the menu will close it.
- Behavior remains consistent with the current `menu.js` logic and GSAP animation flow.

### 🔄 Additional Notes

- Verified on latest fork of the repo.
- No CSS was modified; changes are strictly scoped to JS for interactive behavior.
- Compatible with existing code and UI structure.

---

Implementation :


https://github.com/user-attachments/assets/3f577bf1-09c0-4a43-9fb7-b55b8b3d36d7



Let me know if any changes are needed. Happy to revise as required.
