### PR TITLE
Feat: Add "Skip to Prices" and "Skip to Services" buttons with mobile responsiveness

### DIFF
--- a/public/css/projects.css
+++ b/public/css/projects.css
@@ -88,3 +88,52 @@ section.card {
     font-size: 24px;
   }
 }
+
+@media screen and (max-width: 400px) {
+  .skip-button-wrapper {
+    margin-right: 120px;      
+    text-align: center;      
+    z-index: 1;              
+    position: relative;
+   
+  }
+}
+
+.skip-button-wrapper
+{
+  text-align: right;
+  margin-right: 115px;
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.skip-button {
+  background: linear-gradient(to right, #fc002d, #ff6b00);
+  color: white;
+  padding: 10px 20px;
+  text-align: center;
+  border: none;
+  border-radius: 20px;
+  font-size: 16px;
+  font-family: var(--font-secondary);
+  text-transform: uppercase;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.3s ease, box-shadow 0.3s ease, transform 0.2s ease;
+  display: inline-block;
+}
+
+.skip-button:hover{
+  box-shadow: 0 0 150px 20px rgba(255, 106, 0, 0.75);
+  transform: translateY(-2px);
+   z-index: 2;
+}
+
+
+@media screen and (max-width: 400px) {
+.skip-button {
+   padding: 10px 10px;
+  }
+}
+

--- a/public/js/projects.js
+++ b/public/js/projects.js
@@ -43,3 +43,26 @@ document.addEventListener("DOMContentLoaded", function () {
     );
   });
 });
+
+const skipButtonPrices = document.querySelector('.skip-to-prices');        
+const skipButtonService = document.querySelector('.skip-to-services');        
+const priceSection = document.querySelector('.prices-hero');
+const serviceSection = document.querySelector('.services');
+
+
+if(skipButtonPrices && priceSection)
+{
+  skipButtonPrices.addEventListener('click',() =>
+  {
+    priceSection.scrollIntoView({behavior : "smooth"});
+  })
+}
+
+
+if(skipButtonService && serviceSection)
+{
+  skipButtonService.addEventListener('click',() =>
+  {
+    serviceSection.scrollIntoView({behavior : "smooth"});
+  })
+}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -545,6 +545,9 @@
           </div>
         </section>
 
+        <div class="skip-button-wrapper">
+       <button class="skip-button skip-to-prices">Skip to Prices</button> </div>
+
         <!-- projects -->
         <section class="sticky-cards">
           <section class="projecr-hero pinned"></section>
@@ -713,6 +716,10 @@
 
           <section class="footer"></section>
         </section>
+
+      <div class="skip-button-wrapper">
+       <button class="skip-button skip-to-services">Skip to Services</button>
+      </div>
 
         <!-- prices  -->
         <section class="prices-hero" id="prices">


### PR DESCRIPTION
## 📄 Description

This pull request introduces two new buttons: **"Skip to Prices"** and **"Skip to Services"** for improved navigation. After implementing the buttons, I also ensured they are **fully responsive on mobile devices** (≤ 400px width), with proper alignment and spacing using CSS media queries.

## 🛠️ Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (fixes mobile alignment)
- [x] Refactor
- [ ] Documentation update

## 📱 Screenshots (If applicable)

**Desktop View:**
- Buttons appear right-aligned as expected.

https://github.com/user-attachments/assets/5057d05d-97ff-4e13-9762-f2737b668232



**Mobile View (≤ 400px):**
- Buttons appear right-aligned as expected.
<img width="1385" height="878" alt="image" src="https://github.com/user-attachments/assets/bb5b72d6-b9bd-485d-bd27-2353fff4164b" />
---
<img width="1386" height="875" alt="image" src="https://github.com/user-attachments/assets/cca28442-ac97-4f05-8743-424f3597c5db" />


## ✅ Checklist

- [x] Added both navigation buttons
- [x] Made the buttons responsive for mobile
- [x] Tested on different screen sizes
- [x] Code follows project guidelines

## 🔗 Related Issue

Closes #39

