### PR TITLE
Fix intermittent hover issue on service items

### DIFF
--- a/public/css/services.css
+++ b/public/css/services.css
@@ -24,6 +24,7 @@
 
 .service-item {
   position: relative;
+  z-index: 10;   /*the menu-container was overlapping on the div and hence z-index was given... Bug resolved*/
   width: 100%;
   aspect-ratio: 1;
   display: flex;


### PR DESCRIPTION
## Description
Fixed inconsistent hover effect in the Services section where hover styles would sometimes not trigger. The issue was caused by overlapping elements and pointer events.

## Changes
- Updated CSS to ensure hover always registers

## Testing
1. Go to the Services section.
2. Hover over each service card.
3. Verify the hover effect triggers every time on both desktop and mobile views.

## Checklist
- [✅] Bug fixed
- [✅] Tested on multiple screen sizes
- [✅] No console errors

## Screenshot
https://github.com/user-attachments/assets/a3320e42-fb3d-4806-85a2-106f1ee044bf



