### PR TITLE
fixed csrf protection for all routes

### DIFF
--- a/middleware/csrf.middleware.js
+++ b/middleware/csrf.middleware.js
@@ -4,100 +4,114 @@ const { doubleCsrf } = require("csrf-csrf");
 const doubleCsrfOptions = {
   getSecret: () => {
     const secret = process.env.CSRF_SECRET || "your-secret-key-change-this-in-production";
-    console.log('🔐 CSRF Secret used:', secret ? 'SET' : 'NOT_SET');
-    console.log('🔐 Environment:', process.env.NODE_ENV || 'development');
+    console.log("🔐 CSRF Secret used:", secret ? "SET" : "NOT_SET");
+    console.log("🔐 Environment:", process.env.NODE_ENV || "development");
     if (!process.env.CSRF_SECRET) {
-      console.warn('⚠️ CSRF_SECRET environment variable not set, using fallback secret');
+      console.warn("⚠️ CSRF_SECRET environment variable not set, using fallback secret");
     }
     return secret;
   },
   cookieName: "_csrf",
   cookieOptions: {
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
     maxAge: 3600000, // 1 hour
-    path: '/',
+    path: "/",
   },
   size: 64,
   ignoredMethods: ["GET", "HEAD", "OPTIONS"],
   getTokenFromRequest: (req) => {
     // Check multiple possible locations for the token
-    const token = req.body._csrf || 
-                  req.query._csrf || 
-                  req.headers["x-csrf-token"] || 
-                  req.headers["X-CSRF-Token"] || 
-                  req.headers["x-xsrf-token"] ||
-                  req.cookies._csrf; // Also check cookies
-    
-    console.log('🔐 Token extracted from request:', token ? 'FOUND' : 'NOT_FOUND');
-    console.log('🔐 Token source:', req.body._csrf ? 'body._csrf' : 
-                               req.query._csrf ? 'query._csrf' : 
-                               req.headers["x-csrf-token"] ? 'header.x-csrf-token' : 
-                               req.headers["X-CSRF-Token"] ? 'header.X-CSRF-Token' : 
-                               req.headers["x-xsrf-token"] ? 'header.x-xsrf-token' : 
-                               req.cookies._csrf ? 'cookie._csrf' : 'none');
-    
+    const token =
+      req.body._csrf ||
+      req.query._csrf ||
+      req.headers["x-csrf-token"] ||
+      req.headers["X-CSRF-Token"] ||
+      req.headers["x-xsrf-token"] ||
+      req.cookies._csrf; // Also check cookies
+
+    console.log("🔐 Token extracted from request:", token ? "FOUND" : "NOT_FOUND");
+    console.log(
+      "🔐 Token source:",
+      req.body._csrf
+        ? "body._csrf"
+        : req.query._csrf
+          ? "query._csrf"
+          : req.headers["x-csrf-token"]
+            ? "header.x-csrf-token"
+            : req.headers["X-CSRF-Token"]
+              ? "header.X-CSRF-Token"
+              : req.headers["x-xsrf-token"]
+                ? "header.x-xsrf-token"
+                : req.cookies._csrf
+                  ? "cookie._csrf"
+                  : "none"
+    );
+
     return token;
   },
 };
 
 // Extract the functions directly from doubleCsrf
-const {
-  invalidCsrfTokenError,
-  generateToken,
-  doubleCsrfProtection,
-} = doubleCsrf(doubleCsrfOptions);
+const { invalidCsrfTokenError, generateToken, doubleCsrfProtection } =
+  doubleCsrf(doubleCsrfOptions);
 
 // Debug: Log what we got
-console.log('🔐 generateToken type:', typeof generateToken);
-console.log('🔐 doubleCsrfProtection type:', typeof doubleCsrfProtection);
+console.log("🔐 generateToken type:", typeof generateToken);
+console.log("🔐 doubleCsrfProtection type:", typeof doubleCsrfProtection);
 
 // Since generateToken might be undefined, let's create a fallback
-const safeGenerateToken = generateToken || ((req, res) => {
-  // Generate a simple fallback token
-  const fallbackToken = Math.random().toString(36).substring(2) + Date.now().toString(36);
-  console.log('🔐 Using fallback token generator');
-  return fallbackToken;
-});
+const safeGenerateToken =
+  generateToken ||
+  ((req, res) => {
+    // Generate a simple fallback token
+    const fallbackToken = Math.random().toString(36).substring(2) + Date.now().toString(36);
+    console.log("🔐 Using fallback token generator");
+    return fallbackToken;
+  });
 
 // Create a token store to sync between our custom endpoint and the middleware
 const tokenStore = new Map();
 
 // Clean up expired tokens every 5 minutes
-setInterval(() => {
-  const now = Date.now();
-  const expiredTokens = [];
-  
-  for (const [token, data] of tokenStore.entries()) {
-    if (now - data.createdAt > 3600000) { // 1 hour
-      expiredTokens.push(token);
+setInterval(
+  () => {
+    const now = Date.now();
+    const expiredTokens = [];
+
+    for (const [token, data] of tokenStore.entries()) {
+      if (now - data.createdAt > 3600000) {
+        // 1 hour
+        expiredTokens.push(token);
+      }
     }
-  }
-  
-  expiredTokens.forEach(token => tokenStore.delete(token));
-  
-  if (expiredTokens.length > 0) {
-    console.log(`🧹 Cleaned up ${expiredTokens.length} expired CSRF tokens`);
-  }
-}, 5 * 60 * 1000); // 5 minutes
+
+    expiredTokens.forEach((token) => tokenStore.delete(token));
+
+    if (expiredTokens.length > 0) {
+      console.log(`🧹 Cleaned up ${expiredTokens.length} expired CSRF tokens`);
+    }
+  },
+  5 * 60 * 1000
+); // 5 minutes
 
 // Helper function for final fallback validation
 const handleFinalFallback = (req, res, next, customToken) => {
-  console.log('⚠️ Using final fallback CSRF validation');
+  console.log("⚠️ Using final fallback CSRF validation");
   if (!customToken) {
     return res.status(403).json({
       success: false,
-      message: 'CSRF token missing',
-      error: 'CSRF_TOKEN_MISSING'
+      message: "CSRF token missing",
+      error: "CSRF_TOKEN_MISSING",
     });
   }
   // Simple token validation
   if (customToken.length < 10) {
     return res.status(403).json({
       success: false,
-      message: 'Invalid CSRF token',
-      error: 'CSRF_TOKEN_INVALID'
+      message: "Invalid CSRF token",
+      error: "CSRF_TOKEN_INVALID",
     });
   }
   next();
@@ -105,44 +119,72 @@ const handleFinalFallback = (req, res, next, customToken) => {
 
 // CSRF protection middleware
 const csrfProtection = (req, res, next) => {
-  console.log('🔒 CSRF Protection applied to:', req.path);
-  console.log('🔒 Request method:', req.method);
-  console.log('🔒 CSRF token in body:', req.body._csrf ? 'PRESENT' : 'MISSING');
-  console.log('🔒 CSRF token in cookies:', req.cookies._csrf ? 'PRESENT' : 'MISSING');
-  
-  // First, try to validate using our custom token system
-  const customToken = req.body._csrf || req.cookies._csrf || req.headers['x-csrf-token'] || req.headers['X-CSRF-Token'];
-  console.log('🔍 Custom token found:', customToken ? 'YES' : 'NO');
-  console.log('🔍 Token in store:', customToken ? tokenStore.has(customToken) : 'N/A');
-  console.log('🔍 Total tokens in store:', tokenStore.size);
-  console.log('🔍 Token source:', req.body._csrf ? 'body._csrf' : req.cookies._csrf ? 'cookie._csrf' : req.headers['x-csrf-token'] ? 'header.x-csrf-token' : req.headers['X-CSRF-Token'] ? 'header.X-CSRF-Token' : 'none');
-  console.log('🔍 Token value (first 20 chars):', customToken ? customToken.substring(0, 20) + '...' : 'N/A');
-  console.log('🔍 All tokens in store:', Array.from(tokenStore.keys()).map(t => t.substring(0, 20) + '...'));
-  
-  if (customToken && tokenStore.has(customToken)) {
-    console.log('✅ Custom token validation successful');
-    // Remove the token after successful validation (one-time use)
-    tokenStore.delete(customToken);
-    console.log('🔍 Token removed from store, remaining:', tokenStore.size);
+  console.log("🔒 CSRF Protection applied to:", req.path);
+  console.log("🔒 Request method:", req.method);
+
+  // Skip CSRF protection for GET, HEAD, and OPTIONS requests
+  if (["GET", "HEAD", "OPTIONS"].includes(req.method)) {
+    console.log("🔒 Skipping CSRF protection for safe method:", req.method);
     return next();
   }
-  
+
+  console.log("🔒 CSRF token in body:", req.body._csrf ? "PRESENT" : "MISSING");
+  console.log("🔒 CSRF token in cookies:", req.cookies._csrf ? "PRESENT" : "MISSING");
+
+  // First, try to validate using our custom token system
+  const customToken =
+    req.body._csrf ||
+    req.cookies._csrf ||
+    req.headers["x-csrf-token"] ||
+    req.headers["X-CSRF-Token"];
+  console.log("🔍 Custom token found:", customToken ? "YES" : "NO");
+  console.log("🔍 Token in store:", customToken ? tokenStore.has(customToken) : "N/A");
+  console.log("🔍 Total tokens in store:", tokenStore.size);
+  console.log(
+    "🔍 Token source:",
+    req.body._csrf
+      ? "body._csrf"
+      : req.cookies._csrf
+        ? "cookie._csrf"
+        : req.headers["x-csrf-token"]
+          ? "header.x-csrf-token"
+          : req.headers["X-CSRF-Token"]
+            ? "header.X-CSRF-Token"
+            : "none"
+  );
+  console.log(
+    "🔍 Token value (first 20 chars):",
+    customToken ? customToken.substring(0, 20) + "..." : "N/A"
+  );
+  console.log(
+    "🔍 All tokens in store:",
+    Array.from(tokenStore.keys()).map((t) => t.substring(0, 20) + "...")
+  );
+
+  if (customToken && tokenStore.has(customToken)) {
+    console.log("✅ Custom token validation successful");
+    // Remove the token after successful validation (one-time use)
+    tokenStore.delete(customToken);
+    console.log("🔍 Token removed from store, remaining:", tokenStore.size);
+    return next();
+  }
+
   // If custom validation fails, try to use doubleCsrfProtection but catch its errors
-  if (typeof doubleCsrfProtection === 'function') {
-    console.log('🔄 Falling back to doubleCsrfProtection');
+  if (typeof doubleCsrfProtection === "function") {
+    console.log("🔄 Falling back to doubleCsrfProtection");
     // Wrap the doubleCsrfProtection call to catch any synchronous errors
     const wrappedNext = (err) => {
       if (err) {
-        console.log('🚨 doubleCsrfProtection error caught, using final fallback');
+        console.log("🚨 doubleCsrfProtection error caught, using final fallback");
         return handleFinalFallback(req, res, next, customToken);
       }
       next();
     };
-    
+
     try {
       return doubleCsrfProtection(req, res, wrappedNext);
     } catch (error) {
-      console.log('🚨 doubleCsrfProtection synchronous error, using final fallback');
+      console.log("🚨 doubleCsrfProtection synchronous error, using final fallback");
       return handleFinalFallback(req, res, next, customToken);
     }
   } else {
@@ -154,21 +196,65 @@ const csrfProtection = (req, res, next) => {
 // Middleware to expose CSRF token to all templates
 const exposeCsrfToken = (req, res, next) => {
   try {
-    // Use the safe token generator
-    const token = safeGenerateToken(req, res);
+    // Generate a simple but secure CSRF token for every request
+    const token =
+      Math.random().toString(36).substring(2) +
+      Date.now().toString(36) +
+      Math.random().toString(36).substring(2);
+
+    // Store the token in our token store for validation
+    tokenStore.set(token, {
+      createdAt: Date.now(),
+      origin: req.get("Origin") || "Unknown",
+      userAgent: req.get("User-Agent"),
+    });
+
+    // Set the token in a cookie for the client
+    const cookieOptions = {
+      httpOnly: false, // Allow JavaScript access
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 3600000, // 1 hour
+      path: "/",
+    };
+
+    res.cookie("_csrf", token, cookieOptions);
+
+    // Make token available to templates and requests
     res.locals.csrfToken = token;
-    
-    // Also make it available as a function for compatibility
     req.csrfToken = () => token;
-    
-    // Debug logging
-    console.log('🔐 CSRF Token generated for:', req.path);
-    
+
+    // Debug logging for non-static resources
+    if (!req.path.includes(".") && !req.path.startsWith("/api/")) {
+      console.log(
+        "🔐 CSRF Token auto-generated for:",
+        req.path,
+        "Token:",
+        token.substring(0, 20) + "..."
+      );
+    }
+
     next();
   } catch (error) {
-    console.error('❌ Error generating CSRF token:', error);
+    console.error("❌ Error generating CSRF token:", error);
     // Generate fallback token
     const fallbackToken = Math.random().toString(36).substring(2) + Date.now().toString(36);
+
+    // Store fallback token too
+    tokenStore.set(fallbackToken, {
+      createdAt: Date.now(),
+      origin: req.get("Origin") || "Unknown",
+      userAgent: req.get("User-Agent"),
+    });
+
+    res.cookie("_csrf", fallbackToken, {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 3600000,
+      path: "/",
+    });
+
     res.locals.csrfToken = fallbackToken;
     req.csrfToken = () => fallbackToken;
     next();
@@ -177,36 +263,36 @@ const exposeCsrfToken = (req, res, next) => {
 
 // CSRF error handler middleware
 const csrfErrorHandler = (err, req, res, next) => {
-  console.log('🚨 Error caught in CSRF handler:', err.message);
-  console.log('🚨 Error type:', err.constructor.name);
-  console.log('🚨 Error stack:', err.stack);
-  
+  console.log("🚨 Error caught in CSRF handler:", err.message);
+  console.log("🚨 Error type:", err.constructor.name);
+  console.log("🚨 Error stack:", err.stack);
+
   // Check if this is a CSRF error from csrf-csrf
-  if (err.message && (err.message.includes('CSRF') || err.message.includes('invalid csrf token'))) {
-    console.log('🚨 CSRF Token Error:', err.message);
+  if (err.message && (err.message.includes("CSRF") || err.message.includes("invalid csrf token"))) {
+    console.log("🚨 CSRF Token Error:", err.message);
 
     // More robust AJAX detection
     const isAjax =
       req.xhr ||
-      (req.headers.accept && req.headers.accept.indexOf('json') > -1) ||
-      (req.headers['content-type'] && req.headers['content-type'].indexOf('json') > -1) ||
-      req.headers['x-requested-with'] === 'XMLHttpRequest';
+      (req.headers.accept && req.headers.accept.indexOf("json") > -1) ||
+      (req.headers["content-type"] && req.headers["content-type"].indexOf("json") > -1) ||
+      req.headers["x-requested-with"] === "XMLHttpRequest";
 
     if (isAjax) {
       return res.status(403).json({
         success: false,
-        message: 'Invalid security token. Please refresh the page and try again.',
-        error: 'CSRF_TOKEN_INVALID',
+        message: "Invalid security token. Please refresh the page and try again.",
+        error: "CSRF_TOKEN_INVALID",
       });
     }
 
     // Handle regular form submissions
-    if (req.flash && typeof req.flash === 'function') {
-      req.flash('error', 'Security token expired. Please refresh the page and try again.');
+    if (req.flash && typeof req.flash === "function") {
+      req.flash("error", "Security token expired. Please refresh the page and try again.");
     }
 
     // Safer redirect handling
-    const referer = req.get('Referer') || '/';
+    const referer = req.get("Referer") || "/";
     return res.redirect(referer);
   }
 

--- a/public/csrf-test.html
+++ b/public/csrf-test.html
@@ -1,34 +1,74 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CSRF Test</title>
     <style>
-        body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
-        .test-section { margin: 20px 0; padding: 20px; border: 1px solid #ddd; border-radius: 5px; }
-        button { padding: 10px 20px; margin: 10px; background: #007bff; color: white; border: none; border-radius: 5px; cursor: pointer; }
-        button:hover { background: #0056b3; }
-        .result { margin: 10px 0; padding: 10px; background: #f8f9fa; border-radius: 3px; }
-        .success { background: #d4edda; color: #155724; }
-        .error { background: #f8d7da; color: #721c24; }
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .test-section {
+            margin: 20px 0;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+
+        button {
+            padding: 10px 20px;
+            margin: 10px;
+            background: #007bff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: #0056b3;
+        }
+
+        .result {
+            margin: 10px 0;
+            padding: 10px;
+            background: #f8f9fa;
+            border-radius: 3px;
+        }
+
+        .success {
+            background: #d4edda;
+            color: #155724;
+        }
+
+        .error {
+            background: #f8d7da;
+            color: #721c24;
+        }
     </style>
 </head>
+
 <body>
     <h1>CSRF Protection Test</h1>
-    
+
     <div class="test-section">
-        <h3>1. Get CSRF Token</h3>
-        <button onclick="getCsrfToken()">Get CSRF Token</button>
+        <h3>1. Check Auto-Generated CSRF Token</h3>
+        <button onclick="checkAutoToken()">Check Auto Token</button>
+        <button onclick="getCsrfToken()">Get NEW CSRF Token</button>
         <div id="token-result" class="result"></div>
     </div>
-    
+
     <div class="test-section">
         <h3>2. Test CSRF Protection</h3>
         <button onclick="testCsrfProtection()">Test CSRF Protection</button>
         <div id="test-result" class="result"></div>
     </div>
-    
+
     <div class="test-section">
         <h3>3. Test Signup Form (with CSRF)</h3>
         <form id="signup-form">
@@ -53,32 +93,94 @@
     <script>
         let currentCsrfToken = '';
 
+        // Check if CSRF token is automatically available
+        async function checkAutoToken() {
+            try {
+                console.log('📞 Checking auto-generated CSRF token...');
+                console.log('📞 Current cookies:', document.cookie);
+
+                // First check if token is in cookies
+                const cookies = document.cookie.split(';').reduce((acc, cookie) => {
+                    const [key, value] = cookie.trim().split('=');
+                    acc[key] = value;
+                    return acc;
+                }, {});
+
+                const cookieToken = cookies._csrf;
+                console.log('📞 Token from cookie:', cookieToken);
+
+                if (cookieToken) {
+                    currentCsrfToken = cookieToken;
+                    document.getElementById('csrf-input').value = currentCsrfToken;
+                    document.getElementById('token-result').innerHTML =
+                        `<div class="success">✅ Auto-generated CSRF Token found in cookie: ${currentCsrfToken.substring(0, 20)}...<br>
+                        This token was automatically set when the page loaded!</div>`;
+                } else {
+                    // Try to get current token from server
+                    const response = await fetch('/csrf-token/current', {
+                        method: 'GET',
+                        credentials: 'include'
+                    });
+
+                    if (response.ok) {
+                        const data = await response.json();
+                        currentCsrfToken = data.csrfToken;
+                        document.getElementById('csrf-input').value = currentCsrfToken;
+                        document.getElementById('token-result').innerHTML =
+                            `<div class="success">✅ Current CSRF Token: ${currentCsrfToken.substring(0, 20)}...<br>
+                            Source: ${data.source}</div>`;
+                    } else {
+                        document.getElementById('token-result').innerHTML =
+                            `<div class="error">❌ No auto-generated token found. The page may need to be refreshed.</div>`;
+                    }
+                }
+            } catch (error) {
+                console.error('❌ Error checking auto token:', error);
+                document.getElementById('token-result').innerHTML =
+                    `<div class="error">❌ Error: ${error.message}</div>`;
+            }
+        }
+
         async function getCsrfToken() {
             try {
+                console.log('📞 Requesting NEW CSRF token...');
+                console.log('📞 Current cookies before:', document.cookie);
+
                 const response = await fetch('/csrf-token', {
                     method: 'GET',
                     credentials: 'include'
                 });
+
+                console.log('📞 Response status:', response.status);
+                console.log('📞 Response headers:', [...response.headers.entries()]);
+
                 const data = await response.json();
-                
+                console.log('📞 Response data:', data);
+
+                // Check cookies after response
+                console.log('📞 Cookies after request:', document.cookie);
+
                 if (data.csrfToken) {
                     currentCsrfToken = data.csrfToken;
                     document.getElementById('csrf-input').value = currentCsrfToken;
-                    document.getElementById('token-result').innerHTML = 
-                        `<div class="success">✅ CSRF Token received: ${currentCsrfToken.substring(0, 20)}...</div>`;
+                    document.getElementById('token-result').innerHTML =
+                        `<div class="success">✅ NEW CSRF Token received: ${currentCsrfToken.substring(0, 20)}...<br>
+                        Cookie set: ${data.cookieSet}<br>
+                        Current cookies: ${document.cookie}</div>`;
                 } else {
-                    document.getElementById('token-result').innerHTML = 
+                    document.getElementById('token-result').innerHTML =
                         `<div class="error">❌ No CSRF token received</div>`;
                 }
             } catch (error) {
-                document.getElementById('token-result').innerHTML = 
+                console.error('❌ Error getting CSRF token:', error);
+                document.getElementById('token-result').innerHTML =
                     `<div class="error">❌ Error: ${error.message}</div>`;
             }
         }
 
         async function testCsrfProtection() {
             if (!currentCsrfToken) {
-                document.getElementById('test-result').innerHTML = 
+                document.getElementById('test-result').innerHTML =
                     `<div class="error">❌ Please get a CSRF token first</div>`;
                 return;
             }
@@ -96,18 +198,18 @@
                         test: 'data'
                     })
                 });
-                
+
                 const data = await response.json();
-                
+
                 if (response.ok) {
-                    document.getElementById('test-result').innerHTML = 
+                    document.getElementById('test-result').innerHTML =
                         `<div class="success">✅ CSRF Protection Working! ${data.message}</div>`;
                 } else {
-                    document.getElementById('test-result').innerHTML = 
+                    document.getElementById('test-result').innerHTML =
                         `<div class="error">❌ CSRF Error: ${data.message || 'Unknown error'}</div>`;
                 }
             } catch (error) {
-                document.getElementById('test-result').innerHTML = 
+                document.getElementById('test-result').innerHTML =
                     `<div class="error">❌ Error: ${error.message}</div>`;
             }
         }
@@ -115,9 +217,9 @@
         // Handle signup form submission
         document.getElementById('signup-form').addEventListener('submit', async (e) => {
             e.preventDefault();
-            
+
             if (!currentCsrfToken) {
-                document.getElementById('signup-result').innerHTML = 
+                document.getElementById('signup-result').innerHTML =
                     `<div class="error">❌ Please get a CSRF token first</div>`;
                 return;
             }
@@ -136,24 +238,28 @@
                     credentials: 'include',
                     body: JSON.stringify(formObject)
                 });
-                
+
                 const data = await response.json();
-                
+
                 if (response.ok) {
-                    document.getElementById('signup-result').innerHTML = 
+                    document.getElementById('signup-result').innerHTML =
                         `<div class="success">✅ Signup test successful! ${data.message || 'Form submitted'}</div>`;
                 } else {
-                    document.getElementById('signup-result').innerHTML = 
+                    document.getElementById('signup-result').innerHTML =
                         `<div class="error">❌ Signup error: ${data.message || 'Unknown error'}</div>`;
                 }
             } catch (error) {
-                document.getElementById('signup-result').innerHTML = 
+                document.getElementById('signup-result').innerHTML =
                     `<div class="error">❌ Error: ${error.message}</div>`;
             }
         });
 
-        // Auto-get CSRF token when page loads
-        window.addEventListener('load', getCsrfToken);
+        // Auto-check for CSRF token when page loads
+        window.addEventListener('load', () => {
+            console.log('🚀 Page loaded, checking for auto-generated CSRF token...');
+            checkAutoToken();
+        });
     </script>
 </body>
+
 </html>

--- a/server.js
+++ b/server.js
@@ -1,41 +1,41 @@
-const express = require('express');
-const nodemailer = require('nodemailer');
-const path = require('path');
-const cors = require('cors');
-const rateLimit = require('express-rate-limit');
+const express = require("express");
+const nodemailer = require("nodemailer");
+const path = require("path");
+const cors = require("cors");
+const rateLimit = require("express-rate-limit");
 
-require('dotenv').config();
-const mongoose = require('mongoose');
-const flash = require('connect-flash');
-const cookieParser = require('cookie-parser');
-const session = require('express-session');
-const MongoStore = require('connect-mongo');
-const bcrypt = require('bcrypt');
+require("dotenv").config();
+const mongoose = require("mongoose");
+const flash = require("connect-flash");
+const cookieParser = require("cookie-parser");
+const session = require("express-session");
+const MongoStore = require("connect-mongo");
+const bcrypt = require("bcrypt");
 
 // ✅ node-fetch dynamic import fix for Node.js v20+
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+const fetch = (...args) => import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
-const User = require('./models/user.js');
-const Contact = require('./models/contact.js');
-const Job = require('./models/job.js');
-const authRouter = require('./routes/auth.routes.js');
-const { optionalAuth } = require('./middleware/auth.middleware.js');
-const jobFetcher = require('./services/jobFetcher.js');
-const jobRouter = require('./routes/jobAPI.routes.js');
-const searchRouter = require('./routes/searchAPI.routes.js');
-const passport = require('passport');
-require('./utils/passport.js');
+const User = require("./models/user.js");
+const Contact = require("./models/contact.js");
+const Job = require("./models/job.js");
+const authRouter = require("./routes/auth.routes.js");
+const { optionalAuth } = require("./middleware/auth.middleware.js");
+const jobFetcher = require("./services/jobFetcher.js");
+const jobRouter = require("./routes/jobAPI.routes.js");
+const searchRouter = require("./routes/searchAPI.routes.js");
+const passport = require("passport");
+require("./utils/passport.js");
 
 const app = express();
 const PORT = process.env.PORT || 10000;
 
-app.set('trust proxy', 1); // Important for Render
+app.set("trust proxy", 1); // Important for Render
 
 // === Force HTTPS Redirect (for Render) ===
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === "production") {
   app.use((req, res, next) => {
-    if (req.headers['x-forwarded-proto'] !== 'https' && process.env.NODE_ENV === 'production') {
-      return res.redirect('https://' + req.headers.host + req.url);
+    if (req.headers["x-forwarded-proto"] !== "https" && process.env.NODE_ENV === "production") {
+      return res.redirect("https://" + req.headers.host + req.url);
     }
     next();
   });
@@ -45,18 +45,18 @@ if (process.env.NODE_ENV === 'production') {
 async function main() {
   try {
     await mongoose.connect(process.env.MONGODB_URI);
-    console.log('✅ Connected to MongoDB');
+    console.log("✅ Connected to MongoDB");
   } catch (err) {
-    console.error('❌ MongoDB connection error:', err);
+    console.error("❌ MongoDB connection error:", err);
   }
 }
 main();
 
 // === CORS SETUP ===
 const allowedOrigins = [
-  'https://jobsync-new.onrender.com',
-  'https://jobsyncc.netlify.app',
-  'http://localhost:5000',
+  "https://jobsync-new.onrender.com",
+  "https://jobsyncc.netlify.app",
+  "http://localhost:5000",
 ];
 
 // ========== MIDDLEWARE ==========
@@ -66,23 +66,23 @@ app.use(
       if (!origin || allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
-        callback(new Error('CORS not allowed for origin: ' + origin));
+        callback(new Error("CORS not allowed for origin: " + origin));
       }
     },
-    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    methods: ["GET", "POST", "PUT", "DELETE"],
     credentials: true,
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token', 'X-Requested-With'],
-    exposedHeaders: ['Set-Cookie'],
+    allowedHeaders: ["Content-Type", "Authorization", "X-CSRF-Token", "X-Requested-With"],
+    exposedHeaders: ["Set-Cookie"],
   })
 );
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, "public")));
 
-app.set('view engine', 'ejs');
-app.set('views', path.join(__dirname, 'views'));
+app.set("view engine", "ejs");
+app.set("views", path.join(__dirname, "views"));
 
 // Session configuration with MongoStore and flash messages
 app.use(
@@ -95,8 +95,8 @@ app.use(
     }),
     cookie: {
       maxAge: 1000 * 60 * 60 * 24, // 1 day
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
     },
   })
 );
@@ -108,19 +108,30 @@ app.use(passport.session());
 app.use(flash());
 
 // Import CSRF middleware
-const { csrfProtection, exposeCsrfToken, csrfErrorHandler, tokenStore } = require('./middleware/csrf.middleware.js');
+const {
+  csrfProtection,
+  exposeCsrfToken,
+  csrfErrorHandler,
+  tokenStore,
+} = require("./middleware/csrf.middleware.js");
 
 // Apply CSRF protection selectively
 const csrfMiddleware = (req, res, next) => {
-  console.log('🔒 Global CSRF middleware checking:', req.path, req.method);
-  
-  // Skip CSRF for API routes and send-email (handled separately)
-  if (req.path.startsWith('/api/') || req.path === '/send-email') {
-    console.log('🔒 Skipping CSRF for:', req.path);
+  console.log("🔒 Global CSRF middleware checking:", req.path, req.method);
+
+  // Skip CSRF for safe methods (GET, HEAD, OPTIONS)
+  if (["GET", "HEAD", "OPTIONS"].includes(req.method)) {
+    console.log("🔒 Skipping CSRF for safe method:", req.method, req.path);
     return next();
   }
-  
-  console.log('🔒 Applying CSRF protection to:', req.path);
+
+  // Skip CSRF for API routes and send-email (handled separately)
+  if (req.path.startsWith("/api/") || req.path === "/send-email") {
+    console.log("🔒 Skipping CSRF for:", req.path);
+    return next();
+  }
+
+  console.log("🔒 Applying CSRF protection to:", req.path);
   return csrfProtection(req, res, next);
 };
 
@@ -128,10 +139,10 @@ app.use(csrfMiddleware);
 
 // Make flash messages available to all views
 app.use((req, res, next) => {
-  res.locals.success = req.flash('success');
-  res.locals.error = req.flash('error');
-  res.locals.warning = req.flash('warning');
-  res.locals.info = req.flash('info');
+  res.locals.success = req.flash("success");
+  res.locals.error = req.flash("error");
+  res.locals.warning = req.flash("warning");
+  res.locals.info = req.flash("info");
   next();
 });
 
@@ -141,81 +152,121 @@ app.use(exposeCsrfToken);
 // Apply CSRF error handler
 app.use(csrfErrorHandler);
 
-// === CSRF TOKEN ENDPOINT ===
-app.get('/csrf-token', (req, res) => {
+// === CSRF TOKEN ENDPOINTS ===
+// Generate new CSRF token (for explicit requests)
+app.get("/csrf-token", (req, res) => {
   try {
     // Generate a simple but secure CSRF token
-    const token = Math.random().toString(36).substring(2) + Date.now().toString(36) + Math.random().toString(36).substring(2);
-    
-    console.log('🔐 Generating CSRF token for request from:', req.get('Origin') || 'Unknown origin');
-    console.log('🔐 User agent:', req.get('User-Agent'));
-    
+    const token =
+      Math.random().toString(36).substring(2) +
+      Date.now().toString(36) +
+      Math.random().toString(36).substring(2);
+
+    console.log(
+      "🔐 Generating NEW CSRF token for explicit request from:",
+      req.get("Origin") || "Unknown origin"
+    );
+
     // Store the token in our token store for validation
     tokenStore.set(token, {
       createdAt: Date.now(),
-      origin: req.get('Origin') || 'Unknown',
-      userAgent: req.get('User-Agent')
+      origin: req.get("Origin") || "Unknown",
+      userAgent: req.get("User-Agent"),
     });
-    
+
     // Set the token in a cookie for the client
-    res.cookie('_csrf', token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
+    const cookieOptions = {
+      httpOnly: false, // Allow JavaScript access for testing
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
       maxAge: 3600000, // 1 hour
-      path: '/'
-    });
-    
-    console.log('🔐 CSRF token generated, stored, and cookie set:', token.substring(0, 20) + '...');
-    console.log('🔐 Tokens in store:', tokenStore.size);
-    
-    res.json({ 
+      path: "/",
+    };
+
+    res.cookie("_csrf", token, cookieOptions);
+
+    console.log("🔐 NEW CSRF token generated and cookie set:", token.substring(0, 20) + "...");
+    console.log("🔐 Tokens in store:", tokenStore.size);
+
+    res.json({
       csrfToken: token,
-      message: 'CSRF token generated successfully',
-      timestamp: new Date().toISOString()
+      message: "CSRF token generated successfully",
+      timestamp: new Date().toISOString(),
+      cookieSet: true,
     });
   } catch (error) {
-    console.error('❌ Error generating CSRF token:', error);
-    res.status(500).json({ 
-      error: 'Failed to generate CSRF token',
-      message: error.message 
+    console.error("❌ Error generating CSRF token:", error);
+    res.status(500).json({
+      error: "Failed to generate CSRF token",
+      message: error.message,
     });
   }
 });
 
-        // Test CSRF protection endpoint
-        app.post('/test-csrf', (req, res) => {
-          console.log('🧪 Test CSRF endpoint hit');
-          console.log('🧪 Request headers:', req.headers);
-          console.log('🧪 Request body:', req.body);
-          console.log('🧪 Request cookies:', req.cookies);
-          
-          res.json({ 
-            success: true, 
-            message: 'CSRF protection working!',
-            receivedToken: req.body._csrf,
-            cookieToken: req.cookies._csrf,
-            headers: req.headers,
-            timestamp: new Date().toISOString()
-          });
-        });
+// Get current CSRF token (returns existing token from locals/cookie)
+app.get("/csrf-token/current", (req, res) => {
+  try {
+    // Return the token that was auto-generated by the middleware
+    const token = res.locals.csrfToken || req.cookies._csrf;
 
-        // Test CSRF protection WITHOUT token (should fail)
-        app.post('/test-csrf-no-token', (req, res) => {
-          console.log('🧪 Test CSRF NO TOKEN endpoint hit - this should not happen if CSRF protection works');
-          console.log('🚨 CSRF middleware should have blocked this request!');
-          console.log('🚨 Request path:', req.path);
-          console.log('🚨 Request method:', req.method);
-          console.log('🚨 CSRF token in body:', req.body._csrf ? 'PRESENT' : 'MISSING');
-          console.log('🚨 CSRF token in cookies:', req.cookies._csrf ? 'PRESENT' : 'MISSING');
-          console.log('🚨 CSRF token in headers:', req.headers['x-csrf-token'] ? 'PRESENT' : 'MISSING');
-          
-          res.json({ 
-            success: false, 
-            message: 'This should not be reachable without CSRF token',
-            timestamp: new Date().toISOString()
-          });
-        });
+    if (token) {
+      console.log("🔐 Returning current CSRF token:", token.substring(0, 20) + "...");
+      res.json({
+        csrfToken: token,
+        message: "Current CSRF token retrieved",
+        timestamp: new Date().toISOString(),
+        source: res.locals.csrfToken ? "middleware" : "cookie",
+      });
+    } else {
+      res.status(404).json({
+        error: "No CSRF token found",
+        message: "Please refresh the page to get a CSRF token",
+      });
+    }
+  } catch (error) {
+    console.error("❌ Error retrieving current CSRF token:", error);
+    res.status(500).json({
+      error: "Failed to retrieve CSRF token",
+      message: error.message,
+    });
+  }
+});
+
+// Test CSRF protection endpoint
+app.post("/test-csrf", (req, res) => {
+  console.log("🧪 Test CSRF endpoint hit");
+  console.log("🧪 Request headers:", req.headers);
+  console.log("🧪 Request body:", req.body);
+  console.log("🧪 Request cookies:", req.cookies);
+
+  res.json({
+    success: true,
+    message: "CSRF protection working!",
+    receivedToken: req.body._csrf,
+    cookieToken: req.cookies._csrf,
+    headers: req.headers,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+// Test CSRF protection WITHOUT token (should fail)
+app.post("/test-csrf-no-token", (req, res) => {
+  console.log(
+    "🧪 Test CSRF NO TOKEN endpoint hit - this should not happen if CSRF protection works"
+  );
+  console.log("🚨 CSRF middleware should have blocked this request!");
+  console.log("🚨 Request path:", req.path);
+  console.log("🚨 Request method:", req.method);
+  console.log("🚨 CSRF token in body:", req.body._csrf ? "PRESENT" : "MISSING");
+  console.log("🚨 CSRF token in cookies:", req.cookies._csrf ? "PRESENT" : "MISSING");
+  console.log("🚨 CSRF token in headers:", req.headers["x-csrf-token"] ? "PRESENT" : "MISSING");
+
+  res.json({
+    success: false,
+    message: "This should not be reachable without CSRF token",
+    timestamp: new Date().toISOString(),
+  });
+});
 
 // === RATE LIMITING ===
 const emailRateLimit = rateLimit({
@@ -223,14 +274,14 @@ const emailRateLimit = rateLimit({
   max: 3,
   message: {
     success: false,
-    message: 'Too many email requests from this IP. Please try again in 15 minutes.',
-    error: 'RATE_LIMIT_EXCEEDED',
+    message: "Too many email requests from this IP. Please try again in 15 minutes.",
+    error: "RATE_LIMIT_EXCEEDED",
   },
   handler: (req, res) => {
     console.log(`🚨 Email rate limit exceeded for IP: ${req.ip} at ${new Date().toISOString()}`);
     res.status(429).json({
       success: false,
-      message: 'Too many email requests from this IP. Please try again in 15 minutes.',
+      message: "Too many email requests from this IP. Please try again in 15 minutes.",
       retryAfter: Math.round(15 * 60),
     });
   },
@@ -241,14 +292,14 @@ const generalRateLimit = rateLimit({
   max: 100,
   message: {
     success: false,
-    message: 'Too many requests from this IP. Please try again later.',
-    error: 'GENERAL_RATE_LIMIT_EXCEEDED',
+    message: "Too many requests from this IP. Please try again later.",
+    error: "GENERAL_RATE_LIMIT_EXCEEDED",
   },
   handler: (req, res) => {
     console.log(`⚠️ General rate limit exceeded for IP: ${req.ip} at ${new Date().toISOString()}`);
     res.status(429).json({
       success: false,
-      message: 'Too many requests from this IP. Please try again later.',
+      message: "Too many requests from this IP. Please try again later.",
     });
   },
 });
@@ -256,28 +307,28 @@ const generalRateLimit = rateLimit({
 app.use(generalRateLimit);
 
 // ========== ROUTES ==========
-app.get('/', optionalAuth, (req, res) => {
-  res.render('index.ejs');
+app.get("/", optionalAuth, (req, res) => {
+  res.render("index.ejs");
 });
 
-app.use('/', authRouter);
-app.use('/api/jobs', jobRouter);
-app.use('/api/search', searchRouter);
+app.use("/", authRouter);
+app.use("/api/jobs", jobRouter);
+app.use("/api/search", searchRouter);
 
 // === PROXY EXTERNAL API TO BYPASS CORS ===
-app.get('/api/totalusers', async (req, res) => {
+app.get("/api/totalusers", async (req, res) => {
   try {
-    const response = await fetch('https://sc.ecombullet.com/api/dashboard/totalusers');
+    const response = await fetch("https://sc.ecombullet.com/api/dashboard/totalusers");
     const data = await response.json();
     res.json(data);
   } catch (err) {
-    console.error('❌ External API fetch failed:', err);
-    res.status(500).json({ error: 'Failed to fetch external data' });
+    console.error("❌ External API fetch failed:", err);
+    res.status(500).json({ error: "Failed to fetch external data" });
   }
 });
 
 // Proxy for Google Custom Search API
-app.get('/api/google-search', async (req, res) => {
+app.get("/api/google-search", async (req, res) => {
   try {
     const { q, num = 10, start = 1 } = req.query;
 
@@ -289,7 +340,7 @@ app.get('/api/google-search', async (req, res) => {
     const engineId = process.env.GOOGLE_SEARCH_ENGINE_API;
 
     if (!apiKey || !engineId) {
-      return res.status(500).json({ error: 'Google API credentials not configured' });
+      return res.status(500).json({ error: "Google API credentials not configured" });
     }
 
     const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${engineId}&q=${encodeURIComponent(q)}&num=${num}&start=${start}`;
@@ -311,14 +362,14 @@ app.get('/api/google-search', async (req, res) => {
     const data = await response.json();
 
     if (data.error) {
-      console.error('Google API returned error:', data.error);
+      console.error("Google API returned error:", data.error);
       return res.status(400).json({ error: data.error });
     }
 
     res.json(data);
   } catch (err) {
-    console.error('Google search proxy failed:', err);
-    res.status(500).json({ error: 'Failed to proxy Google search request' });
+    console.error("Google search proxy failed:", err);
+    res.status(500).json({ error: "Failed to proxy Google search request" });
   }
 });
 
@@ -326,7 +377,7 @@ app.get('/api/google-search', async (req, res) => {
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: process.env.SMTP_PORT,
-  secure: process.env.SMTP_SECURE === 'true',
+  secure: process.env.SMTP_SECURE === "true",
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASS,
@@ -337,18 +388,18 @@ const transporter = nodemailer.createTransport({
 });
 
 // Email route with rate limiting only (CSRF excluded in middleware)
-app.post('/send-email', emailRateLimit, async (req, res) => {
-  console.log('📩 Incoming form submission:', req.body);
+app.post("/send-email", emailRateLimit, async (req, res) => {
+  console.log("📩 Incoming form submission:", req.body);
 
   const { user_name, user_role, user_email, portfolio_link, message } = req.body;
 
   if (!user_name || !user_role || !user_email || !message) {
-    return res.status(400).json({ success: false, message: 'Please fill in all required fields.' });
+    return res.status(400).json({ success: false, message: "Please fill in all required fields." });
   }
 
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   if (!emailRegex.test(user_email)) {
-    return res.status(400).json({ success: false, message: 'Please enter a valid email address.' });
+    return res.status(400).json({ success: false, message: "Please enter a valid email address." });
   }
 
   try {
@@ -369,17 +420,17 @@ app.post('/send-email', emailRateLimit, async (req, res) => {
              <strong>Role:</strong> ${user_role}<br>
              <strong>Email:</strong> ${user_email}<br>
              <strong>Portfolio:</strong> ${portfolio_link}<br><br>
-             <strong>Message:</strong><br>${message.replace(/\n/g, '<br>')}</p>`,
+             <strong>Message:</strong><br>${message.replace(/\n/g, "<br>")}</p>`,
       text: `Name: ${user_name}\nRole: ${user_role}\nEmail: ${user_email}\nPortfolio: ${portfolio_link}\n\nMessage:\n${message}`,
     };
 
     const info = await transporter.sendMail(mailOptions);
     console.log(`✅ Email sent: ${info.messageId}`);
 
-    res.json({ success: true, message: 'Email sent successfully!', messageId: info.messageId });
+    res.json({ success: true, message: "Email sent successfully!", messageId: info.messageId });
   } catch (error) {
-    console.error('❌ Error sending email or saving to DB:', error);
-    res.status(500).json({ success: false, message: 'Failed to send email.' });
+    console.error("❌ Error sending email or saving to DB:", error);
+    res.status(500).json({ success: false, message: "Failed to send email." });
   }
 });
 
@@ -394,20 +445,20 @@ app.listen(PORT, async () => {
     console.log(`📊 Current active jobs in database: ${jobCount}`);
 
     if (shouldRunInitialFetch) {
-      console.log('🔄 Database has few jobs, running initial fetch...');
+      console.log("🔄 Database has few jobs, running initial fetch...");
       await jobFetcher.init(true);
     } else {
-      console.log('✅ Database has sufficient jobs, only scheduling cron job...');
+      console.log("✅ Database has sufficient jobs, only scheduling cron job...");
       await jobFetcher.init(false);
     }
 
-    console.log('Job Fetcher Service started successfully');
+    console.log("Job Fetcher Service started successfully");
   } catch (error) {
-    console.error('Failed to start Job Fetcher Service:', error);
+    console.error("Failed to start Job Fetcher Service:", error);
   }
 });
 
 // 404 handler
 app.use((req, res, next) => {
-  res.status(404).render('404');
+  res.status(404).render("404");
 });


### PR DESCRIPTION
I’ve fixed the CSRF protection for all routes. Previously, users had to visit /csrf-token to generate their token, but now it’s handled automatically and tokens are generated without any extra step.

Here is a video of demonstration:


https://github.com/user-attachments/assets/143c65a4-cfa1-4600-abe1-0442fd75cab8

