### PR TITLE
Footer UI is fixed and not overlapping now

### DIFF
--- a/public/css/footer.css
+++ b/public/css/footer.css
@@ -1,4 +1,4 @@
-footer {
+section#contact {
   position: relative;
   width: 100%;
   display: flex;
@@ -81,11 +81,17 @@ footer {
   color: #ff6b00;
 }
 
+.site-footer {
+  padding: 2em 1.5em;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 .footer-copyright {
   width: 100%;
-  padding: 0.5em 1.5em 2em 1.5em;
   display: flex;
   justify-content: space-between;
+  max-width: 1600px; /* Constrain width on large screens */
+  margin: 0 auto; /* Center the content */
 }
 
 .footer-copyright p {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -819,8 +819,8 @@
           </div>
         </section>
 
-        <!-- footer  -->
-        <footer id="contact">
+        <!-- contact section -->
+        <section id="contact">
           <div class="footer-bg">
             <img src="./assets/grad.png" alt="" />
           </div>
@@ -902,8 +902,10 @@
               </div>
             </div>
           </form>
+        </section>
 
-
+        <!-- footer -->
+        <footer class="site-footer">
           <div class="footer-copyright">
             <p>JOBSYNC Web</p>
             <p>Privacy Policy</p>


### PR DESCRIPTION
This PR resolves the issue where the footer (“JOBSYNC WEB” and “PRIVACY POLICY”) overlapped with the contact form and SEND panel. The footer is now properly positioned at the bottom of the page, with consistent left/right alignment and improved spacing on wide screens.

@adityagarwal15 
hey, isssue is solved